### PR TITLE
add a fallback value for max_icons_per_row when modifying lab_input icons_positioning.

### DIFF
--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -123,7 +123,8 @@ for _, lab in pairs(data.raw.lab) do
             local area = width * height
 
             local module_alt_mode_width = positioning.separation_multiplier or 1.1 -- width and height of the module icon in tiles
-            local scale = math.min(1.5, (width * 0.8) / module_alt_mode_width / positioning.max_icons_per_row)
+            positioning.max_icons_per_row = positioning.max_icons_per_row or 6
+            scale = math.min(1.5, (width * 0.8) / module_alt_mode_width / positioning.max_icons_per_row)
 
             positioning.shift = {0, -0.5 * scale}
             positioning.scale = scale


### PR DESCRIPTION
Potentially fixes #3 

At first I thought it might have been my PR #2 that caused this issue, but it does not seem to be the case.

I cant replicate the issue specifically from #3, so I don't know what's causing it. But they probably have a modded lab that does not specify max_icons_per_row for their icons_positioning, is my guess.

6 seems to be the default value for max_icons_per_row in lab_input.





